### PR TITLE
Multitouch event x and y are based on the widget size

### DIFF
--- a/lib/widgets/multitouch.js
+++ b/lib/widgets/multitouch.js
@@ -196,8 +196,8 @@ multitouch.prototype.sendit = function() {
 	this.val = new Object();
 	for (var i=0;i<this.clickPos.touches.length;i++) {
 		this.val["touch"+i] = {
-			x: this.clickPos.touches[i].x/this.canvas.width,
-			y: math.invert(this.clickPos.touches[i].y/this.canvas.height)
+			x: this.clickPos.touches[i].x/this.width,
+			y: math.invert(this.clickPos.touches[i].y/this.height)
 		}
 	}
 	this.transmit(this.val);


### PR DESCRIPTION
Fix from using the canvas size, which might be double the size, causing
x and y to sent as 0.5 at the widget edges.